### PR TITLE
Remove countermoves

### DIFF
--- a/Prolix.cpp
+++ b/Prolix.cpp
@@ -332,9 +332,9 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
     /*else if (moves[ply][i] == killers[ply][1]) {
       movescore[ply][i] += 10000;
     }*/
-    else if ((mov & 4095) == counter) {
+    /*else if ((mov & 4095) == counter) {
       movescore[i] += 10000;
-    }
+    }*/
     /*if (see_exceeds(moves[ply][i], color, 0)) {
         movescore[ply][i]+=15000;
     }*/


### PR DESCRIPTION
Elo   | -0.67 +- 3.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 9784 W: 2411 L: 2430 D: 4943
Penta | [37, 1131, 2568, 1126, 30]
https://sscg13.pythonanywhere.com/test/41/