### PR TITLE
Remove LVA

### DIFF
--- a/Prolix.cpp
+++ b/Prolix.cpp
@@ -141,7 +141,7 @@ int Engine::movestrength(int mov, int color) {
   int captured = (mov >> 17) & 7;
   int promoted = (mov >> 21) & 3;
   if (captured) {
-    return 10000 * captured + 12000 * promoted + 10000 - 1000 * piece +
+    return 10000 * captured + 12000 * promoted +
            capthist[color][piece - 2][captured - 2];
   } else {
     return 60000 * promoted + historytable[color][piece - 2][to];


### PR DESCRIPTION
Elo   | -1.07 +- 3.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 12370 W: 2997 L: 3035 D: 6338
Penta | [46, 1407, 3309, 1385, 38]
https://sscg13.pythonanywhere.com/test/44/
bench: 3709331