### PR TITLE
Remove move ordering bonus for quiet promotions

### DIFF
--- a/Prolix.cpp
+++ b/Prolix.cpp
@@ -144,7 +144,7 @@ int Engine::movestrength(int mov, int color) {
     return 10000 * captured + 12000 * promoted +
            capthist[color][piece - 2][captured - 2];
   } else {
-    return 60000 * promoted + historytable[color][piece - 2][to];
+    return historytable[color][piece - 2][to];
   }
 }
 int Engine::quiesce(int alpha, int beta, int color, int depth) {


### PR DESCRIPTION
Elo   | 7.08 +- 7.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 1718 W: 463 L: 428 D: 827
Penta | [2, 147, 526, 182, 2]
https://sscg13.pythonanywhere.com/test/4/