### PR TITLE
Remove capture promotion move score bonus

### DIFF
--- a/Prolix.cpp
+++ b/Prolix.cpp
@@ -139,10 +139,8 @@ int Engine::movestrength(int mov, int color) {
   int to = (mov >> 6) & 63;
   int piece = (mov >> 13) & 7;
   int captured = (mov >> 17) & 7;
-  int promoted = (mov >> 21) & 3;
   if (captured) {
-    return 10000 * captured + 12000 * promoted +
-           capthist[color][piece - 2][captured - 2];
+    return 10000 * captured + capthist[color][piece - 2][captured - 2];
   } else {
     return historytable[color][piece - 2][to];
   }


### PR DESCRIPTION
Elo   | 0.27 +- 3.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 6448 W: 1732 L: 1727 D: 2989
Penta | [6, 602, 2005, 603, 8]
https://sscg13.pythonanywhere.com/test/5/