### PR TITLE
Always replace TT in PVnode

### DIFF
--- a/Prolix.cpp
+++ b/Prolix.cpp
@@ -452,8 +452,7 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
       }
     }
   }
-  if ((update && !stopsearch) &&
-      ((bestmove1 >= 0) && (abs(bestscore) < 29000))) {
+  if (((update || allnode) && !stopsearch) && (abs(bestscore) < 29000)) {
     updatett(index, depth, bestscore, 2 + allnode,
              Bitboards.moves[ply][bestmove1]);
   }


### PR DESCRIPTION
Elo   | 3.97 +- 2.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11640 W: 3268 L: 3135 D: 5237
Penta | [22, 1075, 3488, 1218, 17]
https://sscg13.pythonanywhere.com/test/41/