### PR TITLE
age TT entries faster

### DIFF
--- a/Frolic.cpp
+++ b/Frolic.cpp
@@ -214,7 +214,7 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
   int bestmove1 = -1;
   int ttdepth = TT[index].depth;
   int ttage = std::max(Bitboards.gamelength - TT[index].age, 0);
-  bool update = (depth >= (ttdepth - ttage / 3));
+  bool update = (depth >= (ttdepth - ttage / 2));
   bool isPV = (beta - alpha > 1);
   int staticeval = EUNN.evaluate(color);
   bool incheck = (Bitboards.checkers(color) != 0ULL);


### PR DESCRIPTION
Elo   | 5.91 +- 4.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 10.00]
Games | N: 10174 W: 3189 L: 3016 D: 3969
Penta | [284, 1133, 2131, 1204, 335]
http://sscg13.pythonanywhere.com/test/50/