### PR TITLE
Optimize nnue with copy make + linux compilation

### DIFF
--- a/Frolic.cpp
+++ b/Frolic.cpp
@@ -431,7 +431,7 @@ int Engine::iterative(int color) {
   auto timetaken =
       std::chrono::duration_cast<std::chrono::milliseconds>(now - start);
   if (proto == "uci") {
-    int nps = 1000 * (Bitboards.nodecount / std::max(1LL, timetaken.count()));
+    int nps = 1000 * (Bitboards.nodecount / std::max((U64)1, (U64)timetaken.count()));
     std::cout << "info nodes " << Bitboards.nodecount << " nps " << nps
               << std::endl;
   }

--- a/Frolic.cpp
+++ b/Frolic.cpp
@@ -669,7 +669,6 @@ void Engine::uci() {
         mov += ucicommand[i];
       }
     }
-
     EUNN.initializennue(Bitboards.Bitboards);
   }
   if (ucicommand.substr(0, 12) == "position fen") {

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,19 @@ CXX := clang++
 
 CXXFLAGS := -O3 -march=$(ARCH) -static -pthread -DEUNNfile=\"$(EVALFILE)\"
 
-SUFFIX := .exe
+DEBUGFLAGS := -g -march=$(ARCH) -static -pthread -DEUNNfile=\"$(EVALFILE)\"
+
+SUFFIX :=
+
+ifeq ($(OS), Windows_NT)
+	SUFFIX := .exe
+endif
 
 OUT := $(EXE)$(SUFFIX)
 
 
 $(EXE): $(SOURCES)
 	$(CXX) $^ $(CXXFLAGS) -o $(OUT)
+
+debug: $(SOURCES)
+	$(CXX) $^ $(DEBUGFLAGS) -o debug$(SUFFIX)


### PR DESCRIPTION
Elo   | 31.49 +- 15.60 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 3.08 (-2.94, 2.94) [0.00, 10.00]
Games | N: 896 W: 312 L: 231 D: 353
Penta | [13, 88, 196, 107, 44]
https://sscg13.pythonanywhere.com/test/785/