### PR TITLE
use quadratic bonus for quiet history

### DIFF
--- a/Frolic.cpp
+++ b/Frolic.cpp
@@ -309,7 +309,7 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
             if ((mov >> 16) & 1) {
               Histories.updatenoisyhistory(mov, depth * depth);
             } else {
-              Histories.updatequiethistory(mov, depth * depth * depth);
+              Histories.updatequiethistory(mov, depth * depth);
             }
             return score;
           }


### PR DESCRIPTION
Elo   | 7.27 +- 7.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-5.00, 5.00]
Games | N: 3392 W: 1010 L: 939 D: 1443
Penta | [86, 387, 698, 420, 105]
https://sscg13.pythonanywhere.com/test/1444/